### PR TITLE
Fix z-index issue agenda items

### DIFF
--- a/app/styles/custom-components/_vlc-agenda-items-section-header.scss
+++ b/app/styles/custom-components/_vlc-agenda-items-section-header.scss
@@ -10,6 +10,7 @@ padding: 1.2rem;
     position: sticky;
     height: 4.8rem;
     top: 0;
+    z-index: 9999;
   }
 }
 


### PR DESCRIPTION
There was an issue with the z-index of the sticky header from the agenda items on the detail view. 
Should be fixed with this.