### PR TITLE
Revert "Fix z-index issue agenda items"

### DIFF
--- a/app/styles/custom-components/_vlc-agenda-items-section-header.scss
+++ b/app/styles/custom-components/_vlc-agenda-items-section-header.scss
@@ -10,7 +10,6 @@ padding: 1.2rem;
     position: sticky;
     height: 4.8rem;
     top: 0;
-    z-index: 9999;
   }
 }
 


### PR DESCRIPTION
Reverts kanselarij-vlaanderen/kaleidos-frontend#5
This z-index destroys different modals & selects.