### PR TITLE
Lazy partial rendering for agenda view

### DIFF
--- a/app/components/agenda/agenda-list/list-item/template.hbs
+++ b/app/components/agenda/agenda-list/list-item/template.hbs
@@ -14,83 +14,85 @@
     {{/if}}
   </pre>
 </h4>
-{{#if (not selectedAgendaItem)}}
-  {{#if (or (await agendaitem.subcase) agendaitem.showAsRemark)}} {{!-- What is this test for? Determining if announcement better through "showAsRemark"? --}}
-    {{#if agendaitem.shortTitle}} {{!-- Avoid rendering the same thing twice if no "shortTitle" exists --}}
-      <p class="vl-u-text">
-        {{agendaitem.title}}
-      </p>
+{{#if renderDetails}}
+  {{#if (not selectedAgendaItem)}}
+    {{#if (or (await agendaitem.subcase) agendaitem.showAsRemark)}} {{!-- What is this test for? Determining if announcement better through "showAsRemark"? --}}
+      {{#if agendaitem.shortTitle}} {{!-- Avoid rendering the same thing twice if no "shortTitle" exists --}}
+        <p class="vl-u-text">
+          {{agendaitem.title}}
+        </p>
+      {{/if}}
     {{/if}}
   {{/if}}
-{{/if}}
-<div class="vl-u-display-flex vl-u-flex-space-between">
-  {{#if (and selectedAgendaItem isEditingOverview)}}
-    <span class="vlc-agenda-meta__times-passed vl-u-text--capitalize vl-u-flex-grow">
-    </span>
-  {{else}}
-    <span class="vlc-agenda-meta__times-passed vl-u-text--capitalize vl-u-flex-grow">
-      {{await agendaitem.subcase.subcaseName}}
-    </span>
-  {{/if}}
-  <div class="vlc-agenda-meta__status-holder">
-    <span class="added-tag vlc-agenda-meta__recently-added">
-      {{#if (await agendaitem.checkAdded)}}
-        <i class="vl-link__icon vl-vi vl-vi-calendar-add"></i>
-        {{#attach-popover
-          placement="top"
-          class="ember-attacher-popper ember-attacher-popper-wide"
-        }}
-          <p>
-            {{t "added-agendaitem-text"}}
-          </p>
-        {{/attach-popover}}
-      {{/if}}
-    </span>
-    {{#if isEditor}}
-      {{#if (not isEditingOverview)}}
-        {{#if agendaitem.formallyOkToShow.approved}}
-          <p class="{{agendaitem.formallyOkToShow.classNames}}">
-            {{agendaitem.formallyOkToShow.label}}
-            <i class="vl-vi vl-vi-check-small" aria-hidden="true"></i>
-          </p>
-        {{else}}
-          <p class="{{agendaitem.formallyOkToShow.classNames}}">
-            {{agendaitem.formallyOkToShow.label}}
-          </p>
+  <div class="vl-u-display-flex vl-u-flex-space-between">
+    {{#if (and selectedAgendaItem isEditingOverview)}}
+      <span class="vlc-agenda-meta__times-passed vl-u-text--capitalize vl-u-flex-grow">
+      </span>
+    {{else}}
+      <span class="vlc-agenda-meta__times-passed vl-u-text--capitalize vl-u-flex-grow">
+        {{await agendaitem.subcase.subcaseName}}
+      </span>
+    {{/if}}
+    <div class="vlc-agenda-meta__status-holder">
+      <span class="added-tag vlc-agenda-meta__recently-added">
+        {{#if (await agendaitem.checkAdded)}}
+          <i class="vl-link__icon vl-vi vl-vi-calendar-add"></i>
+          {{#attach-popover
+             placement="top"
+             class="ember-attacher-popper ember-attacher-popper-wide"
+          }}
+            <p>
+              {{t "added-agendaitem-text"}}
+            </p>
+          {{/attach-popover}}
         {{/if}}
-      {{else}}
-        {{utils/formally-ok-selector
-          formallyOk=formallyOk
-          isLoading=isLoading
-          hideLabel=hideLabel
-          setAction=(action "setAction")
-        }}
+      </span>
+      {{#if isEditor}}
+        {{#if (not isEditingOverview)}}
+          {{#if agendaitem.formallyOkToShow.approved}}
+            <p class="{{agendaitem.formallyOkToShow.classNames}}">
+              {{agendaitem.formallyOkToShow.label}}
+              <i class="vl-vi vl-vi-check-small" aria-hidden="true"></i>
+            </p>
+          {{else}}
+            <p class="{{agendaitem.formallyOkToShow.classNames}}">
+              {{agendaitem.formallyOkToShow.label}}
+            </p>
+          {{/if}}
+        {{else}}
+          {{utils/formally-ok-selector
+            formallyOk=formallyOk
+            isLoading=isLoading
+            hideLabel=hideLabel
+            setAction=(action "setAction")
+          }}
+        {{/if}}
       {{/if}}
-    {{/if}}
-    {{#if (and agendaitem.showAsRemark (not agendaitem.showInNewsletter))}}
-      <i class="vl-button__icon vl-vi vl-vi-hide vl-u-spacer-extended-left-s opacity-lighter"></i>
-    {{/if}}
-    {{#if (await agendaitem.subcase.confidential)}}
-      <span
-        class="vl-icon vl-vi vl-vi-lock vl-u-text--error vl-u-spacer-extended-left-s"
-      ></span>
-    {{/if}}
+      {{#if (and agendaitem.showAsRemark (not agendaitem.showInNewsletter))}}
+        <i class="vl-button__icon vl-vi vl-vi-hide vl-u-spacer-extended-left-s opacity-lighter"></i>
+      {{/if}}
+      {{#if (await agendaitem.subcase.confidential)}}
+        <span
+          class="vl-icon vl-vi vl-vi-lock vl-u-text--error vl-u-spacer-extended-left-s"
+        ></span>
+      {{/if}}
+    </div>
   </div>
-</div>
-{{#if (not selectedAgendaItem)}}
-  {{#if (await agendaitem.documents)}}
-    <div class="vlc-hr"></div>
-    {{utils/documents-list-for-item
-      isClickable=isDocumentClickable
-      item=agendaitem
-      agendaitem=agendaitem
-    }}
-  {{else if (await agendaitem.subcase.documents)}}
-    <div class="vlc-hr"></div>
-    {{utils/documents-list-for-item
-      isClickable=isDocumentClickable
-      item=(await agendaitem.subcase)
-      agendaitem=(await agendaitem.subcase)
-    }}
+  {{#if (not selectedAgendaItem)}}
+    {{#if (await agendaitem.documents)}}
+      <div class="vlc-hr"></div>
+      {{utils/documents-list-for-item
+        isClickable=isDocumentClickable
+        item=agendaitem
+        agendaitem=agendaitem
+      }}
+    {{else if (await agendaitem.subcase.documents)}}
+      <div class="vlc-hr"></div>
+      {{utils/documents-list-for-item
+        isClickable=isDocumentClickable
+        item=(await agendaitem.subcase)
+        agendaitem=(await agendaitem.subcase)
+      }}
+    {{/if}}
   {{/if}}
 {{/if}}


### PR DESCRIPTION
The agenda can be very very big and the amount of data on a page can
be too much for humans and for computers to efficiently process.  This
lazy loading should help in such cases where the majority of the data
is only fetched when the item is on screen.