### PR TITLE
KAS-1170: Extra fixes for new modals

### DIFF
--- a/app/components/subcases/assign-to-meeting-form/template.hbs
+++ b/app/components/subcases/assign-to-meeting-form/template.hbs
@@ -12,7 +12,7 @@
     {{/if}}
   </div>
 </div>
-<div class="vlc-navbar vlc-navbar--no-padding vlc-navbar--bordered-top">
+<div class="vlc-navbar vlc-navbar--bordered-top">
   <div class="vlc-toolbar">
     <div class="vlc-toolbar__left">
       <div class="vlc-toolbar__item">

--- a/app/components/utils/edit-mandatee/template.hbs
+++ b/app/components/utils/edit-mandatee/template.hbs
@@ -41,7 +41,7 @@
     }}
   </div>
 </div>
-<div class="vlc-navbar vlc-navbar--no-padding vlc-navbar--bordered-top">
+<div class="vlc-navbar vlc-navbar--bordered-top">
   <div class="vlc-toolbar">
     <div class="vlc-toolbar__left">
       <div class="vlc-toolbar__item">

--- a/app/components/web-components/vl-modal-verify/template.hbs
+++ b/app/components/web-components/vl-modal-verify/template.hbs
@@ -6,7 +6,7 @@
       tabindex="-1"
       role="dialog"
     >
-      <div class="vlc-navbar vlc-navbar--no-padding">
+      <div class="vlc-navbar">
         <div class="vlc-toolbar">
           <div class="vlc-toolbar__left">
             <div class="vlc-toolbar__item">
@@ -39,36 +39,38 @@
         </p>
       </div>
       {{#if showActions}}
-        <div class="vlc-toolbar">
-          <div class="vlc-toolbar__left">
-            <div class="vlc-toolbar__item">
-              <button
-                type="button"
-                class="vl-button vl-button--link vl-button--narrow"
-                {{action "cancel"}}
-              >
-                {{t "cancel"}}
-              </button>
-            </div>
-          </div>
-          <div class="vlc-toolbar__right">
-            {{#if showVerify}}
+        <div class="vlc-navbar">
+          <div class="vlc-toolbar">
+            <div class="vlc-toolbar__left">
               <div class="vlc-toolbar__item">
-                {{#web-components/vl-save-button
-                  class=buttonClass
-                  isLoading=isLoading
-                  saveAction=(action "verify")
-                }}
-                  {{#if showIcon}}
-                    <i
-                      class="vl-button__icon vl-button__icon--before vl-vi vl-vi-trash"
-                      aria-hidden="true"
-                    ></i>
-                  {{/if}}
-                  {{verifyButtonText}}
-                {{/web-components/vl-save-button}}
+                <button
+                  type="button"
+                  class="vl-button vl-button--link vl-button--narrow"
+                  {{action "cancel"}}
+                >
+                  {{t "cancel"}}
+                </button>
               </div>
-            {{/if}}
+            </div>
+            <div class="vlc-toolbar__right">
+              {{#if showVerify}}
+                <div class="vlc-toolbar__item">
+                  {{#web-components/vl-save-button
+                    class=buttonClass
+                    isLoading=isLoading
+                    saveAction=(action "verify")
+                  }}
+                    {{#if showIcon}}
+                      <i
+                        class="vl-button__icon vl-button__icon--before vl-vi vl-vi-trash"
+                        aria-hidden="true"
+                      ></i>
+                    {{/if}}
+                    {{verifyButtonText}}
+                  {{/web-components/vl-save-button}}
+                </div>
+              {{/if}}
+            </div>
           </div>
         </div>
       {{/if}}

--- a/app/styles/govflanders/components/_modal.scss
+++ b/app/styles/govflanders/components/_modal.scss
@@ -41,17 +41,10 @@ $modal-max-height: calc(100vh - #{$nav-header-height});
   border: 0;
   box-shadow: $base-box-shadow;
   z-index: z("modal");
+  outline: none;
 
   &::backdrop {
     @include backdrop;
-  }
-
-  &[open] {
-    display: block;
-
-    &:focus {
-      outline: auto $outline-color 3px;
-    }
   }
 
   &--static {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1874332/72616710-c9cf1e00-3937-11ea-9b81-65c8fca83d68.png)

![image](https://user-images.githubusercontent.com/1874332/72616735-d3f11c80-3937-11ea-8fe9-b3aa8b30efb1.png)

* Did a proactive search of the common padding problem and found some more hidden candidates
* Fixed outline from webuniverse which we no longer need/want
* Fixed some issues regarding padding missing in the confirmation dialogs