### PR TITLE
KAS-1044: Fix breaking case-filter datepickers for Firefox

### DIFF
--- a/app/components/agendaitems/agendaitems-filter/template.hbs
+++ b/app/components/agendaitems/agendaitems-filter/template.hbs
@@ -90,7 +90,7 @@
   <div
     class="vl-form-grid vl-form-grid--is-stacked vl-u-flex-align-right vl-u-spacer custom-search"
   >
-    <div class="vl-col--2-12 vlc-input-field-block">
+    <div class="vlc-input-field-block">
       {{web-components/vl-form-label value=(t "from-date")}}
       {{web-components/vl-datepicker
           selectedDate=dateFrom
@@ -103,7 +103,7 @@
         </button>
       {{/if}}
     </div>
-    <div class="vl-col--2-12 vlc-input-field-block">
+    <div class="vlc-input-field-block">
       {{web-components/vl-form-label value=(t "until-date")}}
       {{web-components/vl-datepicker
           selectedDate=dateTo

--- a/app/components/cases/cases-filter/template.hbs
+++ b/app/components/cases/cases-filter/template.hbs
@@ -1,6 +1,4 @@
-<div
-        class="vl-form-grid vl-form-grid--is-stacked vl-u-flex-align-right vl-u-spacer-extended-bottom-s"
->
+<div class="vl-form-grid vl-form-grid--is-stacked vl-u-flex-align-right vl-u-spacer-extended-bottom-s">
   <div class="vl-col--4-12 vl-col--1-1--s">
     <label class="vl-form__label" for="dossierId">
       {{t "agendaitem-case"}}
@@ -32,7 +30,7 @@
   <div
           class="vl-form-grid vl-form-grid--is-stacked vl-u-flex-align-right vl-u-spacer custom-search"
   >
-    <div class="vl-col--2-12 vlc-input-field-block">
+    <div class="vlc-input-field-block">
       {{web-components/vl-form-label value=(t "from-date")}}
       {{web-components/vl-datepicker
               selectedDate=dateFrom
@@ -45,7 +43,7 @@
         </button>
       {{/if}}
     </div>
-    <div class="vl-col--2-12 vlc-input-field-block">
+    <div class="vlc-input-field-block">
       {{web-components/vl-form-label value=(t "until-date")}}
       {{web-components/vl-datepicker
               selectedDate=dateTo


### PR DESCRIPTION
**BEFORE**
![image](https://user-images.githubusercontent.com/1874332/73953804-3a4ad880-4901-11ea-8a59-20c375fb321f.png)

**AFTER**
![image](https://user-images.githubusercontent.com/1874332/73953876-4cc51200-4901-11ea-9057-d10552abfb9b.png)


It's mainly to fix the bug. The resulting layout isn't actually that bad. So I'm leaving this as-is