### PR TITLE
KAS-973: Fix Firefox print bug 🔥🦊

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -209,7 +209,7 @@ a.disabled {
 
 body > .ember-view {
   height: 100% !important;
-  display: block;
+  display: flex;
   flex-direction: column;
   overflow: hidden !important;
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -209,7 +209,7 @@ a.disabled {
 
 body > .ember-view {
   height: 100% !important;
-  display: flex;
+  display: block;
   flex-direction: column;
   overflow: hidden !important;
 }

--- a/app/styles/print/_print.scss
+++ b/app/styles/print/_print.scss
@@ -56,7 +56,7 @@
     border: none;
   }
 
-  .vl-u-no-overflow {
-    overflow: auto !important;
+  body > .ember-view {
+    display: block !important;
   }
 }

--- a/app/styles/print/_print.scss
+++ b/app/styles/print/_print.scss
@@ -55,4 +55,8 @@
   .vlc-page-header .vlc-page-header__title--bordered {
     border: none;
   }
+
+  .vl-u-no-overflow {
+    overflow: auto !important;
+  }
 }


### PR DESCRIPTION
**BEFORE**
![image](https://user-images.githubusercontent.com/1874332/74663659-794c1a00-519c-11ea-8b76-3a85964aca18.png)

**AFTER**
![image](https://user-images.githubusercontent.com/1874332/74663947-10b16d00-519d-11ea-81a3-26cb4f9c729e.png)

**WHAT**
There was a bug in Firefox in which multiple pages were not visible. Only the first page would be printed out. This bug has been very typical for Firefox, and is still not fixed on their side to date.

**FIX**
A way to fix this, is to ensure that all containers have `display: block`. There was a child of the `<body>` element `.ember-view` with a `display: flex`. There's also an `overflow: hidden` on the body, but this doesn't matter so much.