### PR TITLE
WIP: Mock-login: Allow scroll

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -96,6 +96,7 @@ $icon-font-location: '/fonts/';
 @import 'custom-components/vlc-input-field-block';
 @import 'custom-components/vlc-list-section-header';
 @import 'custom-components/vlc-minister';
+@import 'custom-components/vlc-mock-login';
 @import 'custom-components/vlc-navbar';
 @import 'custom-components/vlc-page-header';
 @import 'custom-components/vlc-panel-layout';

--- a/app/styles/custom-components/_vlc-mock-login.scss
+++ b/app/styles/custom-components/_vlc-mock-login.scss
@@ -1,0 +1,6 @@
+.vlc-mock-login {
+  // Allow scroll by restricting height to viewport
+  // Subtract from viewport height the header
+  height: calc(100vh - 4.4rem);
+  overflow: auto;
+}

--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -1,5 +1,5 @@
 {{!-- template-lint-disable no-bare-strings --}}
-<div class="page">
+<div class="page vlc-mock-login">
   <div id="main" itemprop="mainContentOfPage" role="main" tabindex="-1" class="main-content">
     <header class="content-header content-header--small content-header--half-image u-spacer--large">
       <div class="content-header__wrapper">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1874332/74829929-5e9bb180-5312-11ea-9bda-546d7afdc207.png)

⚠️ Don't merge yet. @woutersf will take care of the rest 🔝 

Allows you to scroll in the mock-login. For smaller viewports this was quite annoying. A small change with happy developers as a result 😌👌